### PR TITLE
Floored the slide width calculation

### DIFF
--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -309,9 +309,9 @@
 			// if carousel, use the thresholds to determine the width
 			}else{
 				if(wrapWidth > slider.maxThreshold){
-					newElWidth = (wrapWidth - (slider.settings.slideMargin * (slider.settings.maxSlides - 1))) / slider.settings.maxSlides;
+					newElWidth = Math.floor( (wrapWidth - (slider.settings.slideMargin * (slider.settings.maxSlides - 1))) / slider.settings.maxSlides );
 				}else if(wrapWidth < slider.minThreshold){
-					newElWidth = (wrapWidth - (slider.settings.slideMargin * (slider.settings.minSlides - 1))) / slider.settings.minSlides;
+					newElWidth = Math.floor( (wrapWidth - (slider.settings.slideMargin * (slider.settings.minSlides - 1))) / slider.settings.minSlides );
 				}
 			}
 			return newElWidth;


### PR DESCRIPTION
I was setting up a slider like so
<code>
$slider.bxSlider({
            minSlides: 1,
            maxSlides: 5,
            slideWidth: 174,
            slideMargin: 17,
            moveSlides: 3,
            pager: false,
            infiniteLoop: false,
            hideControlOnEnd:true
        });
</code>
and was getting widths like 174.4px

which is no good, this just floors that calculation.

I haven't minimized the js.
