### PR TITLE
A couple smaller fixes to increase compatibility

### DIFF
--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -159,7 +159,7 @@
 			// also strip any margin and padding from el
 			el.css({
 				width: slider.settings.mode == 'horizontal' ? slider.children.length * 215 + '%' : 'auto',
-				position: 'relative',
+				position: 'relative'
 			});
 			// if using CSS, add the easing property
 			if(slider.usingCSS && slider.settings.easing){
@@ -177,9 +177,9 @@
 			});
 			// apply css to all slider children
 			slider.children.css({
-				float: slider.settings.mode == 'horizontal' ? 'left' : 'none',
+				'float': slider.settings.mode == 'horizontal' ? 'left' : 'none',
 				width: getSlideWidth(),
-				listStyle: 'none',
+				listStyle: 'none'
 			});
 			// if slideMargin is supplied, add the css
 			if(slider.settings.mode == 'horizontal' && slider.settings.slideMargin > 0) slider.children.css('marginRight', slider.settings.slideMargin);


### PR DESCRIPTION
Removed trailing commas (which might cause problems in IE8) and added quotes around the "float" identifier, because float is a reserved keyword in JavaScript
