### PR TITLE
Added feature to preload images of only initially visible slides

### DIFF
--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -33,6 +33,7 @@
 		swipeThreshold: 50,
 		video: false,
 		useCSS: true,
+		preloadImages: 'all',
 		
 		// PAGER
 		pager: true,
@@ -209,6 +210,8 @@
 			slider.active.last = slider.settings.startSlide == getPagerQty() - 1;
 			// if video is true, set up the fitVids plugin
 			if(slider.settings.video) el.fitVids();
+
+			var preloadSelector = "*";
 			// only check for control addition if not in "ticker" mode
 			if(!slider.settings.ticker){
 				// if pager is requested, add it
@@ -219,30 +222,39 @@
 				if(slider.settings.auto && slider.settings.autoControls) appendControlsAuto();
 				// if any control option is requested, add the controls wrapper
 				if(slider.settings.controls || slider.settings.autoControls || slider.settings.pager) slider.viewport.after(slider.controls.el);
+				if (slider.settings.preloadImages == "visible") {
+					//preload images of only initially visible slides
+					preloadSelector = ":not(.bx-clone):eq(" + (slider.settings.maxSlides - 1) + ")";
+				}
 			}
-			// preload all images, then perform final DOM / CSS modifications that depend on images being loaded
-			el.children().imagesLoaded(function(){
-				// remove the loading DOM element
-				slider.loader.remove();
-				// set the left / top position of "el"
-				setSlidePosition();
-				// if "vertical" mode, always use adaptiveHeight to prevent odd behavior
-				if (slider.settings.mode == 'vertical') slider.settings.adaptiveHeight = true;
-				// set the viewport height
-				slider.viewport.height(getViewportHeight());
-				// onSliderLoad callback
-				slider.settings.onSliderLoad(slider.active.index);
-				// if auto is true, start the show
-				if (slider.settings.auto && slider.settings.autoStart) initAuto();
-				// if ticker is true, start the ticker
-				if (slider.settings.ticker) initTicker();
-				// if pager is requested, make the appropriate pager link active
-				if (slider.settings.pager) updatePagerActive(slider.settings.startSlide);
-				// check for any updates to the controls (like hideControlOnEnd updates)
-				if (slider.settings.controls) updateDirectionControls();
-				// if touchEnabled is true, setup the touch events
-				if (slider.settings.touchEnabled && !slider.settings.ticker) initTouch();
-			});
+			// preload required images, then perform final DOM / CSS modifications that depend on images being loaded
+			el.children(preloadSelector).imagesLoaded(start);
+		}
+		
+		/**
+		 * Start the slider
+		 */
+		var start = function(){
+			// remove the loading DOM element
+			slider.loader.remove();
+			// set the left / top position of "el"
+			setSlidePosition();
+			// if "vertical" mode, always use adaptiveHeight to prevent odd behavior
+			if (slider.settings.mode == 'vertical') slider.settings.adaptiveHeight = true;
+			// set the viewport height
+			slider.viewport.height(getViewportHeight());
+			// onSliderLoad callback
+			slider.settings.onSliderLoad(slider.active.index);
+			// if auto is true, start the show
+			if (slider.settings.auto && slider.settings.autoStart) initAuto();
+			// if ticker is true, start the ticker
+			if (slider.settings.ticker) initTicker();
+			// if pager is requested, make the appropriate pager link active
+			if (slider.settings.pager) updatePagerActive(slider.settings.startSlide);
+			// check for any updates to the controls (like hideControlOnEnd updates)
+			if (slider.settings.controls) updateDirectionControls();
+			// if touchEnabled is true, setup the touch events
+			if (slider.settings.touchEnabled && !slider.settings.ticker) initTouch();
 		}
 		
 		/**


### PR DESCRIPTION
Currently the script preloads all slides images before starting the slider. This isn't very optimal for user experience as he keeps seeing the loader for a considerable time.

The most common usage of the slider would be to show slideshow with fixed sized images with one slide at a time. In this scenario all required calculations can be done right after the image for first slide is loaded and the slider can be started.

So I added a new feature and related setting option `preloadImages`. With default value "all" you get the current behavior of preloading all images. But you could set it to "visible" which will cause the slider to start after the images for all initially visible images to be loaded.
