### PR TITLE
Fixes whitespace on rotate

### DIFF
--- a/jquery.bxslider.css
+++ b/jquery.bxslider.css
@@ -19,6 +19,7 @@
 	margin: 0 auto 60px;
 	padding: 0;
 	*zoom: 1;
+	overflow-x: hidden;
 }
 
 .bx-wrapper img {


### PR DESCRIPTION
Viewport isn't being updated. If you rotate your iphone from to landscape and back, white space is being added and the page is a little zoomed out. Adding the overflow-x prevents this from happening. 
