### PR TITLE
bxSlider function should return jQuery object when selector does not match anything

### DIFF
--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -84,7 +84,7 @@
 
 	$.fn.bxSlider = function(options){
 		
-		if(this.length == 0) this;
+		if(this.length == 0) return this;
 		
 		// support mutltiple elements
 		if(this.length > 1){


### PR DESCRIPTION
See #113

Properly fixed now! :flushed: 
