### PR TITLE
Position bugfix

### DIFF
--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -1140,9 +1140,16 @@
 					var requestEl = slideIndex * getMoveBy();
 					position = slider.children.eq(requestEl).position();
 				}
-				// plugin values to be animated
-				var value = slider.settings.mode == 'horizontal' ? -(position.left - moveBy) : -position.top;
-				setPositionProperty(value, 'slide', slider.settings.speed);
+				
+				/* If the position doesn't exist 
+				 * (e.g. if you destroy the slider on a next click),
+				 * it doesn't throw an error.
+				 */
+                if ("undefined" !== typeof(position)) {
+                    var value = slider.settings.mode == 'horizontal' ? -(position.left - moveBy) : -position.top;
+                    // plugin values to be animated
+                    setPositionProperty(value, 'slide', slider.settings.speed);
+                }
 			}
 		}
 		


### PR DESCRIPTION
Hey —

Another fix:

When you click next and have a method hooked into onSlideBefore that destroys the slider, it bugs out, because it says the position doesn't exist. This patch fixes it.
