### PR TITLE
Fixed height issue on bx-wrapper when pager mode is disabled

### DIFF
--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -202,6 +202,12 @@
 			slider.viewport.parent().css({
 				maxWidth: getViewportMaxWidth()
 			});
+			// make modification to the wrapper (.bx-wrapper)
+			if(!slider.settings.pager) {
+				slider.viewport.parent().css({
+				margin: '0 auto 0px'
+				});
+			}
 			// apply css to all slider children
 			slider.children.css({
 				'float': slider.settings.mode == 'horizontal' ? 'left' : 'none',


### PR DESCRIPTION
Hi,

Here is a simple fix for the bx-wrapper object that has a wrong height when the page mode is disabled.

Thanks
Seb
