### PR TITLE
Added a new option - AlwaysFullWidth

### DIFF
--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -32,6 +32,7 @@
 		video: false,
 		useCSS: true,
 		preloadImages: 'visible',
+		alwaysFullWidth: false,
 
 		// TOUCH
 		touchEnabled: true,
@@ -345,7 +346,7 @@
 		 */
 		var getViewportMaxWidth = function(){
 			var width = '100%';
-			if(slider.settings.slideWidth > 0){
+			if(slider.settings.slideWidth > 0 && !slider.settings.alwaysFullWidth){
 				if(slider.settings.mode == 'horizontal'){
 					width = (slider.settings.maxSlides * slider.settings.slideWidth) + ((slider.settings.maxSlides - 1) * slider.settings.slideMargin);
 				}else{


### PR DESCRIPTION
I had a use case where I needed the pager to always be centered on the page. Even if there's less slides to fill up the whole width. Therefor I needed a way to keep the wrapper full width.
