### PR TITLE
Apply calculated width to children via .css('width') rather than .width()

### DIFF
--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -209,7 +209,7 @@
 				position: 'relative'
 			});
 			// apply the calculated width after the float is applied to prevent scrollbar interference
-			slider.children.width(getSlideWidth());
+			slider.children.css('width', getSlideWidth());
 			// if slideMargin is supplied, add the css
 			if(slider.settings.mode == 'horizontal' && slider.settings.slideMargin > 0) slider.children.css('marginRight', slider.settings.slideMargin);
 			if(slider.settings.mode == 'vertical' && slider.settings.slideMargin > 0) slider.children.css('marginBottom', slider.settings.slideMargin);


### PR DESCRIPTION
.css('width') can be orders of magnitude faster than .width().  

As per: http://blog.jquery.com/2012/08/16/jquery-1-8-box-sizing-width-csswidth-and-outerwidth/

Fixes extremely slow rendering times with safari when there are more than ~200 children.
