### PR TITLE
Fixed bug 'pagerType: short' when we use maxSlides > 1

### DIFF
--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -733,8 +733,12 @@
 		 */
 		var updatePagerActive = function(slideIndex){
 			// if "short" pager type
+			var len = slider.children.length; // nb of children
 			if(slider.settings.pagerType == 'short'){
-				slider.pagerEl.html((slideIndex + 1) + slider.settings.pagerShortSeparator + slider.children.length);
+				if(slider.settings.maxSlides > 1) {
+					len = Math.ceil(slider.children.length/slider.settings.maxSlides);
+				}
+				slider.pagerEl.html( (slideIndex + 1) + slider.settings.pagerShortSeparator + len);
 				return;
 			}
 			// remove all pager active classes


### PR DESCRIPTION
When we use pagerType option, with maxSlides > 1. The pager show this to: x:(num of page) / y:(num of children). And it reach the end. 

the solution is to have:  x (num page) / y (math.ciel (Number of items / item number that appears))
