### PR TITLE
Fix to loadElements

### DIFF
--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -265,6 +265,10 @@
 
 		var loadElements = function(selector, callback){
 			var total = selector.find('img, iframe').length;
+			if (total == 0){
+				callback();
+				return;
+			}
 			var count = 0;
 			selector.find('img, iframe').each(function(){
 				if($(this).is('img')) $(this).attr('src', $(this).attr('src') + '?timestamp=' + new Date().getTime());


### PR DESCRIPTION
Fixes loadElements to execute the callback and return immediately if the slider doesn't contain anything that needs loading. This stops it showing the loading screen indefinitely.
