### PR TITLE
Add sliderRedraw callback

### DIFF
--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -77,6 +77,7 @@
 		
 		// CALLBACKS
 		onSliderLoad: function() {},
+    onSliderRedraw: function() {},
 		onSlideBefore: function() {},
 		onSlideAfter: function() {},
 		onSlideNext: function() {},
@@ -1257,6 +1258,8 @@
 		 * Update all dynamic slider elements
 		 */
 		el.redrawSlider = function(){
+			// onSliderRedraw callback
+			slider.settings.onSliderRedraw(slider.viewport, getSlideWidth(), getViewportHeight());
 			// resize all children in ratio to new screen size
 			slider.children.add(el.find('.bx-clone')).outerWidth(getSlideWidth());
 			// adjust the height


### PR DESCRIPTION
I'm not sure if you'd like to add this callback into the master but it was very useful to me given the following circumstance:

**The story:**
- I have a slider of _n_ slides
- It is fully responsive (no max height or width)
- Each slide has an image or video that takes up the full width and height of the slide
- Each slide has live text on top of the video or image. This text is absolutely positioned.

**The problem:**

How do I vertically postion text within a dynamic height and width wrapper?

**The idea:**
Using `display: table; height: 100%` and `display: table-cell` I should be able to vertically position my text within a variable height slide. However, for this to work, the parent element needs to have a height set to it and `height: 100%;` breaks the slider height calculations.

**The solution:**
Using the `onSliderRedraw()` callback, I can append the calculated height for the bxslider-viewport to my text wrapper:

```
$( '.feature-slider ul' )bxSlider({
  onSliderRedraw : function(  $sliderViewport, width, height ) {
    $sliderViewport.find( '.feature-intro-wrapper' ).css( 'height', height );
  }
});
```
