### PR TITLE
Fixes bx-viewport height issues

### DIFF
--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -366,6 +366,14 @@
 					return $(this).outerHeight(false);
 				}).get());
 			}
+
+			if(slider.viewport.css('box-sizing') == 'border-box'){
+				height +=	parseFloat(slider.viewport.css('padding-top')) + parseFloat(slider.viewport.css('padding-bottom')) +
+							parseFloat(slider.viewport.css('border-top-width')) + parseFloat(slider.viewport.css('border-bottom-width'));
+			}else if(slider.viewport.css('box-sizing') == 'padding-box'){
+				height +=	parseFloat(slider.viewport.css('padding-top')) + parseFloat(slider.viewport.css('padding-bottom'));
+			}
+
 			return height;
 		}
 


### PR DESCRIPTION
This fixes height issues on the bx-viewport element, when it has padding assigned and also `box-sizing:border-box`.

I mentioned this on this issue: https://github.com/wandoledzep/bxslider-4/issues/140#issuecomment-18177821
