### PR TITLE
Prevent resize from running if slider is destroyed (styles reset issue)

### DIFF
--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -1063,6 +1063,8 @@
 		 * Window resize event callback
 		 */
 		var resizeWindow = function(e){
+			// don't do anything if slider isn't initialized.
+			if(!slider.initialized) return;
 			// get the new window dimens (again, thank you IE)
 			var windowWidthNew = $(window).width();
 			var windowHeightNew = $(window).height();


### PR DESCRIPTION
problem: If the slider is destroyed on a onResize the styles aren't really reset.

Hi, I have found a little bug with the destroy method. I have a website with slider on mobile size and no slider on desktop. For that I use the destroySlider method in a onResize event.

I've found that despite the `$(window).unbind('resize', resizeWindow);` called at the end of the destroy method the resizeWindow get called just one more time after that (at least on chrome 29.0.1547.57). The real problem is that the resizeWindow reapply styles to the container and the slide items, so the `removeAttr("style")` in destroySlider doesn't really work.
