### PR TITLE
Ignore links without data-slide-index inside slides

### DIFF
--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -750,10 +750,12 @@
 			// if auto show is running, stop it
 			if (slider.settings.auto) el.stopAuto();
 			var pagerLink = $(e.currentTarget);
-			var pagerIndex = parseInt(pagerLink.attr('data-slide-index'));
-			// if clicked pager link is not active, continue with the goToSlide call
-			if(pagerIndex != slider.active.index) el.goToSlide(pagerIndex);
-			e.preventDefault();
+			if(pagerLink.attr('data-slide-index') !== undefined){
+				var pagerIndex = parseInt(pagerLink.attr('data-slide-index'));
+				// if clicked pager link is not active, continue with the goToSlide call
+				if(pagerIndex != slider.active.index) el.goToSlide(pagerIndex);
+				e.preventDefault();
+			}
 		}
 		
 		/**


### PR DESCRIPTION
This link must scroll to slide:
&lt;a data-slide-index="1" href=""&gt;Slide #2&lt;/a&gt;

This link must go to URL:
&lt;a href="#top"&gt;Top&lt;/a&gt;
