### PR TITLE
fixed bug for calculating last child width.

### DIFF
--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -481,7 +481,7 @@
 					var lastChild = slider.children.last();
 					var position = lastChild.position();
 					// set the left position
-					setPositionProperty(-(position.left - (slider.viewport.width() - lastChild.width())), 'reset', 0);
+					setPositionProperty(-(position.left - (slider.viewport.width() - lastChild.outerWidth())), 'reset', 0);
 				}else if(slider.settings.mode == 'vertical'){
 					// get the last showing index's position
 					var lastShowingIndex = slider.children.length - slider.settings.minSlides;


### PR DESCRIPTION
When you have moveSlides > 0 and padding & border on each slide, if you reload the slider with startSlide > 0, it's not correctly calculating the position of the startSlide. This fixes it.
