### PR TITLE
[FIX] bad getPagerQty() when moveSlides and infiniteLoop options are on ...

### DIFF
--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -439,7 +439,7 @@
 			// if moveSlides is specified by the user
 			if(slider.settings.moveSlides > 0){
 				if(slider.settings.infiniteLoop){
-					pagerQty = slider.children.length / getMoveBy();
+					pagerQty = Math.ceil(slider.children.length / getMoveBy());
 				}else{
 					// use a while loop to determine pages
 					var breakPoint = 0;


### PR DESCRIPTION
...(can be a non integer value)

Can be fatal : example 4 slides, moveSlides=3, click on prev.
