### PR TITLE
Add ensureSlide public function,

### DIFF
--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -1084,6 +1084,23 @@
 		 */
 
 		/**
+		 * Performs slide transition to the page with the specified slide on it.
+		 *
+		 * @param slideIndex (int) 
+		 *  - the destination slide's index (zero-based)
+		 *
+		 */
+		el.ensureSlide = function (slideIndex) 
+		{
+			if (getNumberSlidesShowing()==1){
+				el.goToSlide(slideIndex);
+				return;   
+			}
+			var pageIndx = Math.floor(slideIndex/getNumberSlidesShowing());
+			el.goToSlide(pageIndx);
+		}
+		
+		/**
 		 * Performs slide transition to the specified slide
 		 *
 		 * @param slideIndex (int)


### PR DESCRIPTION
if you pass it the index of an item it will ensure that the page with that item on it is visible, useful with a responsive carousel, when you want to slide to a specific item.

My use case was 

    var ds = $('#dateSlider').bxSlider({
        speed: 400,
        minSlides: 2,
        maxSlides: 6,
        slideWidth: 130,
        slideMargin: 0,
        pager: false,
        infiniteLoop: false,
        hideControlOnEnd: true  
    });
    
    ds.ensureSlide($("#dateSlider li.selected").index());