### PR TITLE
Add property to specify when to hide the next control

### DIFF
--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -19,6 +19,7 @@
 		slideSelector: '',
 		infiniteLoop: true,
 		hideControlOnEnd: false,
+		slidesBeforeEndToHideNext: 1,
 		speed: 500,
 		easing: null,
 		slideMargin: 0,
@@ -832,9 +833,13 @@
 				// if first slide
 				if (slider.active.index == 0){
 					slider.controls.prev.addClass('disabled');
-					slider.controls.next.removeClass('disabled');
+					
+					if(getPagerQty() > slider.settings.slidesBeforeEndToHideNext)
+						slider.controls.next.removeClass('disabled');
+					else
+						slider.controls.next.addClass('disabled');
 				// if last slide
-				}else if(slider.active.index == getPagerQty() - 1){
+				}else if(slider.active.index >= getPagerQty() - slider.settings.slidesBeforeEndToHideNext){
 					slider.controls.next.addClass('disabled');
 					slider.controls.prev.removeClass('disabled');
 				// if any slide in the middle


### PR DESCRIPTION
We already have a property to hide the next control when we reach the last slide this is "hideControlOnEnd". The problem is that it will slide until only the last slide is visible. if I set the "minSlides" property it will get me close but not right there, on this case when the last slide is visible I can still click next once, and the next slide is still enabled.

I added a property "slidesBeforeEndToHideNext" the default value is "1" so if you don't initialize it the behavior will be the same we have right now, but if you initialize it the "Next" button will be disabled when the last number of slides specified are visible.
