### PR TITLE
Fix invalid css

### DIFF
--- a/jquery.bxslider.css
+++ b/jquery.bxslider.css
@@ -33,7 +33,7 @@
 	-moz-box-shadow: 0 0 5px #ccc;
 	-webkit-box-shadow: 0 0 5px #ccc;
 	box-shadow: 0 0 5px #ccc;
-	border: solid #fff 5px;
+	border:  5px solid #fff;
 	left: -5px;
 	background: #fff;
 }


### PR DESCRIPTION
The existing css does not compile because the properties are in an invalid order.  I discovered this while compiling bxslider into my site css with the recess compiler.
