### PR TITLE
Added a new method to return the current slide element.

### DIFF
--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -1244,6 +1244,13 @@
 		el.getCurrentSlide = function(){
 			return slider.active.index;
 		}
+		
+		/**
+		 * Returns current slide element
+		 */
+		el.getCurrentSlideElement = function(){
+			return slider.children.eq(slider.active.index);
+		}
 
 		/**
 		 * Returns number of slides in show


### PR DESCRIPTION
Fix https://github.com/wandoledzep/bxslider-4/issues/415
