### PR TITLE
minSlides: 1; // at mobile width, the container isn't wide enough --> buggy sliding

### DIFF
--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -188,7 +188,7 @@
 			// set el to a massive width, to hold any needed slides
 			// also strip any margin and padding from el
 			el.css({
-				width: slider.settings.mode == 'horizontal' ? (slider.children.length * 100 + 215) + '%' : 'auto',
+				width: slider.settings.mode == 'horizontal' ? (slider.children.length * 100 + 415) + '%' : 'auto',
 				position: 'relative'
 			});
 			// if using CSS, add the easing property


### PR DESCRIPTION
The container has a width calculation with a 215% added cushion.  This increases that cushion, which helps this work at mobile widths (with 1 slide showing).

http://jsfiddle.net/n9cWN/1/

When more than 1 slide is showing, it seems to work fine.  Size down so that only 1 slide is showing, and you can see as the slider resets itself when you get to the last slide (the infinite loop).

I've noticed that the last slide breaks to a second row (there's not enough room in the container).  In your calculations ([jquery.bxslider.js @ line 191](https://github.com/wandoledzep/bxslider-4/blob/master/jquery.bxslider.js#L191)), you add 215% to the width.  **I'm not familiar with the geometry of this plugin, but it seems that if you bump this to 415, it seems to work fine?**