### PR TITLE
Fixing slider ul's browser default margin and padding, as well as slider bug of showing last item first

### DIFF
--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -494,13 +494,22 @@
 			// if not last slide
 			}else{
 				// get the position of the first showing slide
-				var position = slider.children.eq(slider.active.index * getMoveBy()).position();
+				var firstIndex = slider.active.index * getMoveBy(),
+		        position = slider.children.eq(firstIndex).position();
 				// check for last slide
 				if (slider.active.index == getPagerQty() - 1) slider.active.last = true;
 				// set the repective position
 				if (position != undefined){
-					if (slider.settings.mode == 'horizontal') setPositionProperty(-position.left, 'reset', 0);
-					else if (slider.settings.mode == 'vertical') setPositionProperty(-position.top, 'reset', 0);
+					if (slider.settings.mode == 'horizontal')
+					{
+						position.left = (slider.active.index + 1) * slider.children.eq(firstIndex).outerWidth(true);
+						setPositionProperty(-position.left, 'reset', 0);
+					}
+					else if (slider.settings.mode == 'vertical')
+					{
+						position.top = (slider.active.index + 1) * slider.children.eq(firstIndex).outerHeight(true);
+						setPositionProperty(-position.top, 'reset', 0);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
The default margin value caused the image to have 16px cropped at the bottom.

Also implementing @thdoan's fix for the bug of slider showing last item first. (https://github.com/wandoledzep/bxslider-4/issues/432)
