### PR TITLE
Update jquery.bxslider.css

### DIFF
--- a/jquery.bxslider.css
+++ b/jquery.bxslider.css
@@ -36,6 +36,13 @@
 	border: solid #fff 5px;
 	left: -5px;
 	background: #fff;
+	
+	/*fix other elements on the page moving (on Chrome)*/
+	-webkit-transform: translatez(0);
+	-moz-transform: translatez(0);
+    	-ms-transform: translatez(0);
+    	-o-transform: translatez(0);
+    	transform: translatez(0);
 }
 
 .bx-wrapper .bx-pager,


### PR DESCRIPTION
When a slide is running, some elements further in the page are moving at the same time (on chrome).
Some elements with percent on (width, margin, padding) are affected when a slide is running.

To fix that. I add this css to .bx-viewport div.

-webkit-transform: translatez(0);
-moz-transform: translatez(0);
-ms-transform: translatez(0);
-o-transform: translatez(0);
transform: translatez(0);
