### PR TITLE
adding -webkit specific fix for ul spacing

### DIFF
--- a/jquery.bxslider.css
+++ b/jquery.bxslider.css
@@ -202,3 +202,10 @@
 	font-size: .85em;
 	padding: 10px;
 }
+ul.bxslider {
+	-webkit-margin-before: 0em;
+	-webkit-margin-after: 0em;
+	-webkit-margin-start: 0px;
+	-webkit-margin-end: 0px;
+	-webkit-padding-start: 0px;
+}


### PR DESCRIPTION
Basically I have noticed some jumpiness and it comes from -webkit browsers that add margin-before, margin-after, margin-start, margin-end, padding-start css to ul elements. This removes that, but only if the element has a class of bxslider. might be better to add it via js or another way. But in ticker mode the padding-start that Chrome/Safari adds, makes the slider jump on the last slide typically. By removing that spacing, it removes the jump.