### PR TITLE
Add new option to make goToSlide() interruptible

### DIFF
--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -35,6 +35,7 @@
 		responsive: true,
 		slideZIndex: 50,
 		wrapperClass: 'bx-wrapper',
+		interruptible: false,
 
 		// TOUCH
 		touchEnabled: true,
@@ -1115,7 +1116,7 @@
 		 */
 		el.goToSlide = function(slideIndex, direction){
 			// if plugin is currently in motion, ignore request
-			if(slider.working || slider.active.index == slideIndex) return;
+			if(!slider.settings.interruptible && (slider.working || slider.active.index == slideIndex)) return;
 			// declare that plugin is in motion
 			slider.working = true;
 			// store the old index
@@ -1150,9 +1151,9 @@
 					slider.viewport.animate({height: getViewportHeight()}, slider.settings.adaptiveHeightSpeed);
 				}
 				// fade out the visible child and reset its z-index value
-				slider.children.filter(':visible').fadeOut(slider.settings.speed).css({zIndex: 0});
+				slider.children.filter(':visible').stop(true, true).fadeOut(slider.settings.speed).css({zIndex: 0});
 				// fade in the newly requested slide
-				slider.children.eq(slider.active.index).css('zIndex', slider.settings.slideZIndex+1).fadeIn(slider.settings.speed, function(){
+				slider.children.eq(slider.active.index).css('zIndex', slider.settings.slideZIndex+1).stop(true, true).fadeIn(slider.settings.speed, function(){
 					$(this).css('zIndex', slider.settings.slideZIndex);
 					updateAfterSlideTransition();
 				});

--- a/readme.md
+++ b/readme.md
@@ -231,6 +231,13 @@ default: 'bx-wrapper'
 options: string
 ```
 
+**interruptive**
+If <code>true</code>, goToSlide() method will perform transition even if other slide is in transitioin.
+```
+default: false
+options: boolean (true / false)
+```
+
 ###Pager
 
 **pager**


### PR DESCRIPTION
goToSlide() doesn't perform transition if other slide is working, so I added new option to make goToSlide() interruptible.