### PR TITLE
Storing slider instance as jQuery data for later access through the DOM

### DIFF
--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -169,8 +169,12 @@
 			}());
 			// if vertical mode always make maxSlides and minSlides equal
 			if(slider.settings.mode == 'vertical') slider.settings.maxSlides = slider.settings.minSlides;
-			// save original style data
-			el.data("origStyle", el.attr("style"));
+			el.data({
+				// save slider instance in case we need to act on it later through the DOM
+				bxInstance: el,
+				// save original style data
+				origStyle: el.attr("style")
+			});
 			el.children(slider.settings.slideSelector).each(function() {
 			  $(this).data("origStyle", $(this).attr("style"));
 			});
@@ -1281,6 +1285,13 @@
 		}
 
 		/**
+		 * Returns original options argument
+		 */
+		el.getOptions = function(){
+			return options;
+		}
+
+		/**
 		 * Update all dynamic slider elements
 		 */
 		el.redrawSlider = function(){
@@ -1311,9 +1322,15 @@
 			slider.initialized = false;
 			$('.bx-clone', this).remove();
 			slider.children.each(function() {
-				$(this).data("origStyle") != undefined ? $(this).attr("style", $(this).data("origStyle")) : $(this).removeAttr('style');
+				if ($(this).data("origStyle") != undefined) {
+					$(this).attr("style", $(this).data("origStyle"))
+					$(this).removeData("origStyle");
+				} else { 
+					$(this).removeAttr("style");
+				}
 			});
-			$(this).data("origStyle") != undefined ? this.attr("style", $(this).data("origStyle")) : $(this).removeAttr('style');
+			$(this).data("origStyle") != undefined ? this.attr("style", $(this).data("origStyle")) : $(this).removeAttr("style");
+			$(this).removeData(["origStyle", "bxInstance"]);
 			$(this).unwrap().unwrap();
 			if(slider.controls.el) slider.controls.el.remove();
 			if(slider.controls.next) slider.controls.next.remove();

--- a/readme.md
+++ b/readme.md
@@ -543,6 +543,14 @@ slider = $('.bxslider').bxSlider();
 var slideQty = slider.getSlideCount();
 ```
 
+**getOptions**
+Returns the original options argument used to initialize the slider
+```
+example:
+slider = $('.bxslider').bxSlider({mode:'fade'});
+var slideOptions = slider.getOptions();
+```
+
 **reloadSlider**
 Reload the slider. Useful when adding slides on the fly. Accepts an optional settings object. <a href="/examples/reload-slider-settings">See here for an example.</a>
 ```


### PR DESCRIPTION
I frequently need to execute methods on slider instances when the original handle is not accessible in a standard way, or at all (e.g. hidden in a separate scope). This change adds a "bxInstance" to the slider element using jQuery data as an alternate access point. It also adds a simple getOptions method for getting the original options argument in cases where the slider needs to be reloaded.
