### PR TITLE
Remove vendor prefix for translateZ(0)

### DIFF
--- a/jquery.bxslider.css
+++ b/jquery.bxslider.css
@@ -39,10 +39,6 @@
 	
 	/*fix other elements on the page moving (on Chrome)*/
 	-webkit-transform: translatez(0);
-	-moz-transform: translatez(0);
-    	-ms-transform: translatez(0);
-    	-o-transform: translatez(0);
-    	transform: translatez(0);
 }
 
 .bx-wrapper .bx-pager,


### PR DESCRIPTION
Doesn't need all the vendor prefixes as this is a fix for Chrome, so only `-webkit` is required