### PR TITLE
Add public method to set active index

### DIFF
--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -1274,6 +1274,13 @@
 		}
 
 		/**
+		 * Sets current slide index (zero-based)
+		 */
+		el.setCurrentSlide = function(index){
+			slider.active.index = index;
+		}
+
+		/**
 		 * Returns number of slides in show
 		 */
 		el.getSlideCount = function(){


### PR DESCRIPTION
For scenarios where changing slides on one slider will change slides on another on the same page.  e.g: A main slideshow showing a single image with a thumbnails slideshow underneath that tracks the movement of the main slideshow.

There is a bug somewhere either here on in my code that uses this library whereby jumping back to the start from any other position does not move the slider because it thinks it is already at slide 0.  This tricks the slider into moving.

Would you mind if this public method was added to the library?
