### PR TITLE
wrongly removing custom pager in destroySlider

### DIFF
--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -1318,7 +1318,7 @@
 			if(slider.controls.el) slider.controls.el.remove();
 			if(slider.controls.next) slider.controls.next.remove();
 			if(slider.controls.prev) slider.controls.prev.remove();
-			if(slider.pagerEl && slider.settings.controls) slider.pagerEl.remove();
+			if(slider.pagerEl && slider.settings.controls && !slider.settings.pagerCustom) slider.pagerEl.remove();
 			$('.bx-caption', this).remove();
 			if(slider.controls.autoEl) slider.controls.autoEl.remove();
 			clearInterval(slider.interval);


### PR DESCRIPTION
I'm using a custom pager. I am also using destroySlider() to reset the slider with a mobile responsive site on window resize.  This fix is to prevent the unload of my custom pager on Destroy (since it me who creates it)