### PR TITLE
Made onSlideBefore interruptible so sliding can be stopped.

### DIFF
--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -1110,7 +1110,10 @@
 				slider.active.index = slideIndex;
 			}
 			// onSlideBefore, onSlideNext, onSlidePrev callbacks
-			slider.settings.onSlideBefore(slider.children.eq(slider.active.index), slider.oldIndex, slider.active.index);
+			var returned = slider.settings.onSlideBefore(slider.children.eq(slider.active.index), slider.oldIndex, slider.active.index);
+			if (returned == false) {
+				return;
+			}
 			if(direction == 'next'){
 				slider.settings.onSlideNext(slider.children.eq(slider.active.index), slider.oldIndex, slider.active.index);
 			}else if(direction == 'prev'){


### PR DESCRIPTION
When using bxSlider in a step by step interface, one might want to
validate the current slide before going on to the next. Using this you
can use the onSlideBefore callback to do validations and stop
transition if needed.
