### PR TITLE
fixes for horizontal carousel. clone more depending on container width. fix carousel boolean if only 1 slide.

### DIFF
--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -136,7 +136,8 @@
 			// store active slide information
 			slider.active = { index: slider.settings.startSlide }
 			// store if the slider is in carousel mode (displaying / moving multiple slides)
-			slider.carousel = slider.settings.minSlides > 1 || slider.settings.maxSlides > 1;
+			// last condition is for sliders with only 1 slide.
+			slider.carousel = slider.settings.minSlides > 1 || slider.settings.maxSlides > 1 || (slider.settings.maxSlides <= 1 && slider.settings.minSlides <= 1);
 			// if carousel, force preloadImages = 'all'
 			if(slider.carousel) slider.settings.preloadImages = 'all';
 			// calculate the min / max width thresholds based on min / max number of slides
@@ -192,7 +193,7 @@
 			// set el to a massive width, to hold any needed slides
 			// also strip any margin and padding from el
 			el.css({
-				width: slider.settings.mode == 'horizontal' ? (slider.children.length * 100 + 215) + '%' : 'auto',
+				width: slider.settings.mode == 'horizontal' ? (slider.children.length * 1000 + 215) + '%' : 'auto',
 				position: 'relative'
 			});
 			// if using CSS, add the easing property
@@ -290,10 +291,22 @@
 		var start = function(){
 			// if infinite loop, prepare additional slides
 			if(slider.settings.infiniteLoop && slider.settings.mode != 'fade' && !slider.settings.ticker){
+				var childrenCount = slider.children.length;
+				var slideOuterWidth = el.children('li').first().outerWidth(true);
+				var sliderWidth = el.closest('.bx-viewport').width();
+				var cloneSetsCount = Math.ceil(sliderWidth / (slideOuterWidth * childrenCount));
 				var slice = slider.settings.mode == 'vertical' ? slider.settings.minSlides : slider.settings.maxSlides;
-				var sliceAppend = slider.children.slice(0, slice).clone().addClass('bx-clone');
-				var slicePrepend = slider.children.slice(-slice).clone().addClass('bx-clone');
+				var sliceAppendOrig = slider.children.slice(0, slice);
+				var slicePrependOrig = slider.children.slice(-slice);
+				// make the default clones
+				sliceAppend = sliceAppendOrig.clone().addClass('bx-clone');
+				slicePrepend = slicePrependOrig.clone().addClass('bx-clone');
 				el.append(sliceAppend).prepend(slicePrepend);
+				// if extra clones are needed, append them. the slider auto adjusts so no need for prepend
+				for (var i = cloneSetsCount - 2; i >= 0; i--) {
+					sliceAppend = sliceAppendOrig.clone().addClass('bx-clone');
+					el.append(sliceAppend).prepend(slicePrepend);
+				};
 			}
 			// remove the loading DOM element
 			slider.loader.remove();


### PR DESCRIPTION
Our use case was to create a full page width slider with many fixed width slides. Now there are cases when there is only 1 slide.

This fixes 3 problems in horizontal sliders.
- when the container width is way larger then the width of all slides. e.g. 1200px container, 3 90px slides. gaps are left on the right side or left side when you navigate.
- fixes the logic determining if a slideshow is a carousel if there's only 1 slide. the logic error is that if there's only 1 slide then carousel is false. this results in a jump when navigating left on the leftmost clone slide.
- I also used the small hack in https://github.com/stevenwanderski/bxslider-4/issues/421

Here's an illustration of the gap:
![gaps](https://cloud.githubusercontent.com/assets/676680/4384709/c35bcc94-43ba-11e4-9a5a-22efbe02c020.png)
