### PR TITLE
allow nested childrens for slideSelector

### DIFF
--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -128,6 +128,9 @@
 			slider.settings.slideWidth = parseInt(slider.settings.slideWidth);
 			// store the original children
 			slider.children = el.children(slider.settings.slideSelector);
+			//check for nested childrens
+			if(slider.children.length === 0)
+			    slider.children = el.find(slider.settings.slideSelector);
 			// check if actual number of slides is less than minSlides / maxSlides
 			if(slider.children.length < slider.settings.minSlides) slider.settings.minSlides = slider.children.length;
 			if(slider.children.length < slider.settings.maxSlides) slider.settings.maxSlides = slider.children.length;


### PR DESCRIPTION
This commit allows to set slideSelector as nested children of bx container. I'm using .page as slideSelector for big resolutions and .slide for smaller

&#x3C;section class=&#x22;bx-wrapper&#x22;&#x3E;
&#x9;&#x9;&#x3C;div class=&#x22;page&#x22;&#x3E;
&#x9;&#x9;&#x9;&#x9;&#x3C;div class=&#x22;slide&#x22;&#x3E;content&#x3C;/div&#x3E;
&#x9;&#x9;&#x9;&#x9;&#x3C;div class=&#x22;slide&#x22;&#x3E;content&#x3C;/div&#x3E;
&#x9;&#x9;&#x9;&#x9;&#x3C;div class=&#x22;slide&#x22;&#x3E;content&#x3C;/div&#x3E;
&#x9;&#x9;&#x3C;/div&#x3E;
&#x9;&#x9;&#x3C;div class=&#x22;page&#x22;&#x3E;
&#x9;&#x9;&#x9;&#x9;&#x3C;div class=&#x22;slide&#x22;&#x3E;content&#x3C;/div&#x3E;
&#x9;&#x9;&#x9;&#x9;&#x3C;div class=&#x22;slide&#x22;&#x3E;content&#x3C;/div&#x3E;
&#x9;&#x9;&#x9;&#x9;&#x3C;div class=&#x22;slide&#x22;&#x3E;content&#x3C;/div&#x3E;
&#x9;&#x9;&#x3C;/div&#x3E;
&#x3C;/section&#x3E;
