### PR TITLE
Fix loadElements for SVG image tag in Internet Explorer

### DIFF
--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -269,13 +269,13 @@
 		}
 
 		var loadElements = function(selector, callback){
-			var total = selector.find('img, iframe').length;
+			var total = selector.find('img[src], iframe').length;
 			if (total == 0){
 				callback();
 				return;
 			}
 			var count = 0;
-			selector.find('img, iframe').each(function(){
+			selector.find('img[src], iframe').each(function(){
 				$(this).one('load', function() {
 				  if(++count == total) callback();
 				}).each(function() {


### PR DESCRIPTION
In Internet Explorer querySelector('img') finds SVG image tag (this tag hasnt "complete" property). Selector 'img[src]' can fix this problem.
