### PR TITLE
"Massive width" for the el was not massive enough when max-slides > 1

### DIFF
--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -192,7 +192,7 @@
 			// set el to a massive width, to hold any needed slides
 			// also strip any margin and padding from el
 			el.css({
-				width: slider.settings.mode == 'horizontal' ? (slider.children.length * 100 + 215) + '%' : 'auto',
+				width: slider.settings.mode == 'horizontal' ? ((slider.children.length + (slider.settings.maxSlides * 2)) * 103) + '%' : 'auto',
 				position: 'relative'
 			});
 			// if using CSS, add the easing property


### PR DESCRIPTION
I adjusted the calculation to determine the width of the el to take into consideration the max-slides selected since that increases the number of bx-clones created.