### PR TITLE
pager: false bugfix

### DIFF
--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -1140,7 +1140,7 @@
 			// check if last slide
 			slider.active.last = slider.active.index >= getPagerQty() - 1;
 			// update the pager with active class
-			if(slider.settings.pager) updatePagerActive(slider.active.index);
+			if(slider.settings.pager || slider.settings.pagerCustom) updatePagerActive(slider.active.index);
 			// // check for direction control update
 			if(slider.settings.controls) updateDirectionControls();
 			// if slider is set to mode: "fade"
@@ -1295,9 +1295,14 @@
 			if (slider.active.last) slider.active.index = getPagerQty() - 1;
 			// if the active index (page) no longer exists due to the resize, simply set the index as last
 			if (slider.active.index >= getPagerQty()) slider.active.last = true;
-			// if a pager is being displayed and a custom pager is not being used, update it
-			if(slider.settings.pager && !slider.settings.pagerCustom){
+			// if there is a default pager populate it
+			if (slider.settings.pager) {
 				populatePager();
+				updatePagerActive(slider.active.index);
+			}
+			// if there is a custom pager activate it
+			if (slider.settings.pagerCustom) {
+				appendPager();
 				updatePagerActive(slider.active.index);
 			}
 		}


### PR DESCRIPTION
TL:DR - setting pager:false disables custom pager

When setting a custom pager, I want to be able to disabled all markup injected by the default pager, i.e. `<div class="bx-controls"></div>`.

If I pass `pager: false` then this stops the pager from working, even though `pagerCustom:` has a value.

This pull request repairs this bug.