### PR TITLE
`updateAfterSlideTransition` not being called

### DIFF
--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -269,13 +269,13 @@
 		}
 
 		var loadElements = function(selector, callback){
-			var total = selector.find('img, iframe').length;
+			var total = selector.find('img:not([src=""]), iframe').length;
 			if (total == 0){
 				callback();
 				return;
 			}
 			var count = 0;
-			selector.find('img, iframe').each(function(){
+			selector.find('img:not([src=""]), iframe').each(function(){
 				$(this).one('load', function() {
 				  if(++count == total) callback();
 				}).each(function() {

--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -540,14 +540,18 @@
 				// add the CSS transition-duration
 				el.css('-' + slider.cssPrefix + '-transition-duration', duration / 1000 + 's');
 				if(type == 'slide'){
-					// set the property value
-					el.css(slider.animProp, propValue);
-					// bind a callback method - executes when CSS transition completes
-					el.bind('transitionend webkitTransitionEnd oTransitionEnd MSTransitionEnd', function(){
-						// unbind the callback
-						el.unbind('transitionend webkitTransitionEnd oTransitionEnd MSTransitionEnd');
+					if(value === 0) {
 						updateAfterSlideTransition();
-					});
+					} else {
+						// set the property value
+						el.css(slider.animProp, propValue);
+						// bind a callback method - executes when CSS transition completes
+						el.bind('transitionend webkitTransitionEnd oTransitionEnd MSTransitionEnd', function(){
+							// unbind the callback
+							el.unbind('transitionend webkitTransitionEnd oTransitionEnd MSTransitionEnd');
+							updateAfterSlideTransition();
+						});
+					}
 				}else if(type == 'reset'){
 					el.css(slider.animProp, propValue);
 				}else if(type == 'ticker'){


### PR DESCRIPTION
fixing the `updateAfterSlideTransition` not being called when there is only one slide and there will be no transitionEnd event from Browser