### PR TITLE
This fixes extra space on the left when using fade mode.

### DIFF
--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -233,6 +233,7 @@
 			if(slider.settings.mode == 'fade'){
 				slider.children.css({
 					position: 'absolute',
+					left: 0,
 					zIndex: 0,
 					display: 'none'
 				});


### PR DESCRIPTION
In ticket #611 @gnowland used fade mode because of the responsive issue with horizontal mode. I noticed that there was extra spacing on the left when using fade mode so I added a quick fix.