### PR TITLE
Vertical, minSlides:4, moveSlides:1, children no longer dissapiers

### DIFF
--- a/jquery.bxslider.js
+++ b/jquery.bxslider.js
@@ -347,7 +347,7 @@
 					for (i = 1; i <= slider.settings.maxSlides - 1; i++){
 						// if looped back to the start
 						if(currentIndex + i >= slider.children.length){
-							children = children.add(slider.children.eq(i - 1));
+							children = children.add(slider.children.eq(currentIndex + i - slider.children.length));
 						}else{
 							children = children.add(slider.children.eq(currentIndex + i));
 						}


### PR DESCRIPTION
```
holder.bxSlider({ 
            mode: 'vertical',
            slideWidth: 100,
            minSlides: 4,
            moveSlides: 1
})
```
When going through slides at some point 1 slide dissapears.  
350 line: tries to add already existing element to children array.

With current fix, when currentIndex + i reach sliders children.length it don't include wrong child.
