### PR TITLE
Slider getter trough jquery object 

### DIFF
--- a/src/js/jquery.bxslider.js
+++ b/src/js/jquery.bxslider.js
@@ -1536,6 +1536,9 @@
 
 		init();
 
+		//Save data object to be retrieved async
+		$(el.context).data('boxSlider', this);
+
 		// returns the current jQuery object
 		return this;
 	};


### PR DESCRIPTION
Added support to get the slider object without the needed to be saved in a previous variable, for example, now you can get the slider object by $(element).data('boxSlider').reloadSlider()