### PR TITLE
Added shrinkItems carousel setting

### DIFF
--- a/src/js/jquery.bxslider.js
+++ b/src/js/jquery.bxslider.js
@@ -78,6 +78,7 @@
 		maxSlides: 1,
 		moveSlides: 0,
 		slideWidth: 0,
+		shrinkItems: 0,
 
 		// CALLBACKS
 		onSliderLoad: function(){ return true },
@@ -421,6 +422,9 @@
 					// newElWidth = (wrapWidth - (slider.settings.slideMargin * (slider.settings.maxSlides - 1))) / slider.settings.maxSlides;
 				}else if(wrapWidth < slider.minThreshold){
 					newElWidth = (wrapWidth - (slider.settings.slideMargin * (slider.settings.minSlides - 1))) / slider.settings.minSlides;
+				}else if(slider.settings.shrinkItems){
+					var slidesToShow = Math.ceil((wrapWidth + slider.settings.slideMargin) / (newElWidth + slider.settings.slideMargin));
+					newElWidth = Math.floor((wrapWidth + slider.settings.slideMargin) / slidesToShow - slider.settings.slideMargin);
 				}
 			}
 			return newElWidth;


### PR DESCRIPTION
If we resize browser window e.g. at http://bxslider.com/examples/carousel-dynamic-number-slides, the last slide is cropped for certain widths. Though it's probably appropriate for most cases, it would be great to have an option to display only whole slides by making them respectively smaller (see the screenshot attached). The *shrinkItems* setting added provides such an option.   
![bxslider-shrinkitems](https://cloud.githubusercontent.com/assets/2883497/6689480/79c67b52-cccb-11e4-94cd-0fbab7150917.png)
