### PR TITLE
Fixed transition from first to last slide during infinite loop

### DIFF
--- a/src/js/jquery.bxslider.js
+++ b/src/js/jquery.bxslider.js
@@ -1362,6 +1362,11 @@
 					var eq = slider.settings.moveSlides === 1 ? slider.settings.maxSlides - getMoveBy() : ((getPagerQty() - 1) * getMoveBy()) - (slider.children.length - slider.settings.maxSlides);
 					lastChild = el.children('.bx-clone').eq(eq);
 					position = lastChild.position();
+				// if infinite loop and "Prev" is clicked on the first slide
+				}else if(direction === 'prev' && slider.active.last){
+					// get the first clone position
+					position = el.find('> .bx-clone').eq(0).position();
+					slider.active.last = true;
 				// if infinite loop and "Next" is clicked on the last slide
 				}else if(direction === 'next' && slider.active.index === 0){
 					// get the last clone position


### PR DESCRIPTION
Fixes #777 and https://github.com/stevenwanderski/bxslider-4/issues/758#issuecomment-84655944

Bug demos:

Transition from first to last slide with infinite loop:

![bxslider-bug2](https://cloud.githubusercontent.com/assets/139536/6770363/5513b0f6-d0e8-11e4-9218-8cb1c960c1f2.gif)

Swiping on mobile:

![bxslider-bug](https://cloud.githubusercontent.com/assets/139536/6770236/5664d25e-d0e4-11e4-9d34-c7d44d99fefd.gif)
