### PR TITLE
Added unperfixed CSS transformations for modern Chrome-based browsers

### DIFF
--- a/src/js/jquery.bxslider.js
+++ b/src/js/jquery.bxslider.js
@@ -547,10 +547,12 @@
 				var propValue = slider.settings.mode === 'vertical' ? 'translate3d(0, ' + value + 'px, 0)' : 'translate3d(' + value + 'px, 0, 0)';
 				// add the CSS transition-duration
 				el.css('-' + slider.cssPrefix + '-transition-duration', duration / 1000 + 's');
+				el.css('transition-duration', duration / 1000 + 's');
 				if(type === 'slide'){
 					setTimeout(function() {
 						// set the property value
 						el.css(slider.animProp, propValue);
+						el.css('transform', propValue);
 						// if value 0, just update
 						if(value === 0) {
 							updateAfterSlideTransition();
@@ -565,10 +567,13 @@
 					}, 0);
 				}else if(type === 'reset'){
 					el.css(slider.animProp, propValue);
+    				el.css('transform', propValue);
 				}else if(type === 'ticker'){
 					// make the transition use 'linear'
 					el.css('-' + slider.cssPrefix + '-transition-timing-function', 'linear');
+    				el.css('transition-timing-function', 'linear');
 					el.css(slider.animProp, propValue);
+    				el.css('transform', propValue);
 					// bind a callback method - executes when CSS transition completes
 					el.bind('transitionend webkitTransitionEnd oTransitionEnd MSTransitionEnd', function(){
 						// unbind the callback


### PR DESCRIPTION
Unfortunately bxSlider does not work well with useCSS option in modern Opera and Chrome. Please, consider adding unprefixed css transform after prefixed one.