### PR TITLE
added the passed slider argument to onSloderLoad section for consistent docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -434,8 +434,9 @@ options: integer
 Executes immediately after the slider is fully loaded
 ```
 default: function(){}
-options: function(currentIndex){ // your code here }
+options: function(slider, currentIndex){ // your code here }
 arguments:
+  slider: slider object containing settings, slider elements and state variables
   currentIndex: element index of the current slide
 ```
 


### PR DESCRIPTION
onSlioderLoad passes a slider object as first argument. I was wondering why index was an object when noticed that this (certainly very useful) argument was not documented yet