### PR TITLE
fixes prev and next buttons from inheriting transition settings from parent

### DIFF
--- a/src/css/jquery.bxslider.css
+++ b/src/css/jquery.bxslider.css
@@ -174,3 +174,6 @@ ul.bxslider {
   font-size: .85em;
   padding: 10px;
 }
+.bx-prev, .bx-next{
+  transition:none;
+}


### PR DESCRIPTION
A parent element with transition settings causes the on the next and prev buttons to shift the sprite vertically, not fade on mouseover.