### PR TITLE
Bug with getNumberSlidesShowing when slides have borders

### DIFF
--- a/src/js/jquery.bxslider.js
+++ b/src/js/jquery.bxslider.js
@@ -440,7 +440,7 @@
 					slidesShowing = slider.settings.maxSlides;
 				// if viewport is between min / max thresholds, divide viewport width by first child width
 				}else{
-					var childWidth = slider.children.first().width() + slider.settings.slideMargin;
+					var childWidth = slider.children.first().outerWidth() + slider.settings.slideMargin;
 					slidesShowing = Math.floor((slider.viewport.width() +
 						slider.settings.slideMargin) / childWidth);
 				}


### PR DESCRIPTION
Slides with borders don't have their border width accounted for in getNumberOfSlidesShowing. This causes the slide to be skipped when it's not fully shown. 


Here's a gif illustrating this. The last image that's cutoff is always skipped.
![bx-slider-bug](https://cloud.githubusercontent.com/assets/2387037/8856993/65977f0c-313c-11e5-9dca-7b53a7d80d9b.gif)
