### PR TITLE
Fix incorrect detection of last slide on viewport resize

### DIFF
--- a/dist/jquery.bxslider.js
+++ b/dist/jquery.bxslider.js
@@ -508,7 +508,7 @@
     var setSlidePosition = function() {
       var position, lastChild, lastShowingIndex;
       // if last slide, not infinite loop, and number of children is larger than specified maxSlides
-      if (slider.children.length > slider.settings.maxSlides && slider.active.last && !slider.settings.infiniteLoop) {
+      if (slider.children.length >= slider.settings.maxSlides && slider.active.last && !slider.settings.infiniteLoop) {
         if (slider.settings.mode === 'horizontal') {
           // get the last child's position
           lastChild = slider.children.last();

--- a/src/js/jquery.bxslider.js
+++ b/src/js/jquery.bxslider.js
@@ -500,7 +500,7 @@
     var setSlidePosition = function() {
       var position, lastChild, lastShowingIndex;
       // if last slide, not infinite loop, and number of children is larger than specified maxSlides
-      if (slider.children.length > slider.settings.maxSlides && slider.active.last && !slider.settings.infiniteLoop) {
+      if (slider.children.length >= slider.settings.maxSlides && slider.active.last && !slider.settings.infiniteLoop) {
         if (slider.settings.mode === 'horizontal') {
           // get the last child's position
           lastChild = slider.children.last();


### PR DESCRIPTION
The last slide is jumping to the wrong position on viewport resize:
Before resize: https://www.dropbox.com/s/uk8lf0hgsvn5txe/bxslider-1.jpg?dl=0
After resize: https://www.dropbox.com/s/353mdxsksn0rpht/bxslider-2.jpg?dl=0

With the fixed line, it works well:
https://www.dropbox.com/s/l85v4cleqpcdutr/bxslider-3.jpg?dl=0