### PR TITLE
Clean up events and classes on custom pager when destroying slider.

### DIFF
--- a/src/js/jquery.bxslider.js
+++ b/src/js/jquery.bxslider.js
@@ -1575,6 +1575,8 @@
       if (slider.controls.next) { slider.controls.next.remove(); }
       if (slider.controls.prev) { slider.controls.prev.remove(); }
       if (slider.pagerEl && slider.settings.controls && !slider.settings.pagerCustom) { slider.pagerEl.remove(); }
+      if (slider.pagerEl && slider.settings.controls && slider.settings.pagerCustom) { slider.pagerEl.off('click touchend', 'a', clickPagerBind); }
+      if (slider.pagerEl) { slider.pagerEl.find('.active').removeClass('active'); }
       $('.bx-caption', this).remove();
       if (slider.controls.autoEl) { slider.controls.autoEl.remove(); }
       clearInterval(slider.interval);


### PR DESCRIPTION
When using destroySlider the click and touchend event handler was not being removed and neither was the active class.
