### PR TITLE
Ability to stop slider automatically lock to a slide when in touch mode

### DIFF
--- a/src/js/jquery.bxslider.js
+++ b/src/js/jquery.bxslider.js
@@ -1215,7 +1215,7 @@
         // if not infinite loop and first / last slide, do not attempt a slide transition
         if (!slider.settings.infiniteLoop && ((slider.active.index === 0 && distance > 0) || (slider.active.last && distance < 0))) {
           setPositionProperty(value, 'reset', 200);
-        } else {
+        } else if(slider.settings.lockToSlide) {
           // check if distance clears threshold
           if (Math.abs(distance) >= slider.settings.swipeThreshold) {
             if (distance < 0) {

--- a/src/js/jquery.bxslider.js
+++ b/src/js/jquery.bxslider.js
@@ -30,7 +30,7 @@
     oneToOneTouch: true,
     preventDefaultSwipeX: true,
     preventDefaultSwipeY: false,
-    lockToSlide: false,
+    lockToSlide: true,
 
     // ACCESSIBILITY
     ariaLive: true,

--- a/src/js/jquery.bxslider.js
+++ b/src/js/jquery.bxslider.js
@@ -30,6 +30,7 @@
     oneToOneTouch: true,
     preventDefaultSwipeX: true,
     preventDefaultSwipeY: false,
+    lockToSlide: false,
 
     // ACCESSIBILITY
     ariaLive: true,


### PR DESCRIPTION
I have found a need for this slider to stop the default behavior of locking to the beginning of an image after a touch has completed. This pull request will allow the slider to simply stop moving after the user has completed their swipe with the addition of a new option that defaults to true in order to preserve current behavior. I am not entirely familiar with the source base for this, so if you feel that this is a worthwhile feature, and if there is a better way to do this let me know what to do and I can implement it properly. If you feel that this is worthwhile to add I can also modify the docs to account for the new option.