### PR TITLE
allow for server side paging of data

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -457,7 +457,7 @@ Adds Aria Live attribute to slider.
 default: true
 options: boolean (true / false)
 ```
-    
+
 **ariaHidden**
 Adds Aria Hidden attribute to any nonvisible slides.
 ```
@@ -483,6 +483,16 @@ default: function(){}
 options: function(currentIndex){ // your code here }
 arguments:
   currentIndex: element index of the current slide
+```
+
+**onNeedsData**
+Executes when the next page to be displayed will require more data to be fetched
+```
+default: function($slideElement, callback) { callback(); }
+options: function($slideElement, callback) { // your code here }
+arguments:
+    $slideElement: jQuery element of the destination element
+    callback: function to be called once DOM is updated with new elements
 ```
 
 **onSlideBefore**
@@ -618,7 +628,7 @@ slider.destroySlider();
 From the command line:
 
 1. Install `grunt-cli` and `bower` globally with `npm install -g grunt-cli bower`.
-2. Run `npm install`. npm will look at `package.json` and automatically install the necessary dependencies. 
+2. Run `npm install`. npm will look at `package.json` and automatically install the necessary dependencies.
 3. Run `bower install`, which installs front-end packages defined in `bower.json`.
 
 When completed, you'll be able to run the various Grunt commands provided from the command line.
@@ -648,7 +658,7 @@ Everyone is welcome to help [contribute](CONTRIBUTING.md) and improve this proje
 * Fix: Slider runs into undefined state when reloadSlider is called before initialization was finished #833
 
 ### Version 4.2.4
-NOTICE: We have switched to a Grunt based build process in order to leverage [Assemble](http://assemble.io) for local documentation building. Please review the above notes about Grunt for the commands available. 
+NOTICE: We have switched to a Grunt based build process in order to leverage [Assemble](http://assemble.io) for local documentation building. Please review the above notes about Grunt for the commands available.
 
 * Fix: Fixed transition from first to last slide during infinite loop #778
 * Fix: Reload on multiple sliders doesn't work? #755
@@ -661,7 +671,7 @@ NOTICE: We have switched to a Grunt based build process in order to leverage [As
 * Enhancement: Slider getter through jquery object #739
 * Enhancement: Add aria attributes #751
 * Enhancement: Slider element in every callback and a new method getSliderElement (#780)
-* Enhancement: Local Documentiation and examples. I have added buildable documentation to the repo. This will expand over time and allow for community corrections as needed. Please see above Grunt notes on how to build. 
+* Enhancement: Local Documentiation and examples. I have added buildable documentation to the repo. This will expand over time and allow for community corrections as needed. Please see above Grunt notes on how to build.
 
 
 ### Version 4.2.3

--- a/src/js/jquery.bxslider.js
+++ b/src/js/jquery.bxslider.js
@@ -79,6 +79,7 @@
     onSliderLoad: function() { return true; },
     onSlideBefore: function() { return true; },
     onSlideAfter: function() { return true; },
+    onNeedData: function(slideElement, callback) { callback(false); },
     onSlideNext: function() { return true; },
     onSlidePrev: function() { return true; },
     onSliderResize: function() { return true; }
@@ -480,6 +481,13 @@
         pagerQty = Math.ceil(slider.children.length / getNumberSlidesShowing());
       }
       return pagerQty;
+    };
+
+    var needData = function() {
+        var curr = (slider.active.index + 1) * getNumberSlidesShowing(),
+            needed = curr + getNumberSlidesShowing();
+
+        return !slider.settings.infiniteLoop && needed > slider.children.length;
     };
 
     /**
@@ -1323,7 +1331,7 @@
      * @param direction (string)
      *  - INTERNAL USE ONLY - the direction of travel ("prev" / "next")
      */
-    el.goToSlide = function(slideIndex, direction) {
+    var _goToSlide = function(slideIndex, direction) {
       // onSlideBefore, onSlideNext, onSlidePrev callbacks
       // Allow transition canceling based on returned value
       var performTransition = true,
@@ -1431,6 +1439,17 @@
         }
       }
       if (slider.settings.ariaHidden) { applyAriaHiddenAttributes(slider.active.index * getMoveBy()); }
+    };
+
+    el.goToSlide = function(slideIndex, direction) {
+        if (needData()) {
+            slider.settings.onNeedData(slider.children.eq(slider.active.index), function() {
+               slider.children = el.children(slider.settings.slideSelector);
+                _goToSlide(slideIndex, direction);
+            });
+        } else {
+            _goToSlide(slideIndex, direction);
+        }
     };
 
     /**


### PR DESCRIPTION
Hi, 
I've added a feature which allows clients to page data in from the server, via an event onNeedData, which fires when the next button is clicked, if there is not enough data to display the next full slide. 

Currently the only support that exists for this is reloadSlider, but this provides a very poor experience. We tried that route, and sequence of events is something like this:

1. page to the end, displaying a partial page
2. notice that we're at the end
3. fetching data from the server via $.ajax call
4. update DOM, and call reloadSlider, providing the correct start position

The visual experience is, you see the slider go to the end, displaying partial result, you see a lag, you see a flash as it reinitializes, and you see a visual "jump" as the slider resets to the right position.

So with this pull, the behavior becomes one where pressing the next button causes a tiny lag if an ajax fetch is needed, but once the animation begins its completely smooth.

Thanks!