### PR TITLE
Added 'captionsAttr' options in order customize image caption value

### DIFF
--- a/src/js/jquery.bxslider.js
+++ b/src/js/jquery.bxslider.js
@@ -13,6 +13,7 @@
     startSlide: 0,
     randomStart: false,
     captions: false,
+    captionsAttr: 'title',
     ticker: false,
     tickerHover: false,
     adaptiveHeight: false,
@@ -722,7 +723,7 @@
       // cycle through each child
       slider.children.each(function(index) {
         // get the image title attribute
-        var title = $(this).find('img:first').attr('title');
+        var title = $(this).find('img:first').attr(slider.settings.captionsAttr);
         // append the caption
         if (title !== undefined && ('' + title).length) {
           $(this).append('<div class="bx-caption"><span>' + title + '</span></div>');


### PR DESCRIPTION
This simple PR adds `captionsAttr` option in order to customize `img` attribute from which to get the caption value. Default value is `title` (that is, as the current behaviour).
For example:

**JS**
```javascript
$('.bxslider').bxSlider({
   mode: 'fade',
   captions: true,
   captionsAttr: 'data-caption'
});
```

**HTML**
```html
<ul class="bxslider">
  <li><img src="/images/730_200/tree_root.jpg" title="Funky roots" data-caption="Source: Thinkstock" /></li>
  <li><img src="/images/730_200/hill_road.jpg" title="The long and winding road" data-caption="Source: Flickr" /></li>
  <li><img src="/images/730_200/trees.jpg" title="Happy trees" data-caption="Source: Getty Images" /></li>
</ul>
```