### PR TITLE
Fixing flickering (on -webkit) 

### DIFF
--- a/src/css/jquery.bxslider.css
+++ b/src/css/jquery.bxslider.css
@@ -17,6 +17,8 @@
 .bxslider {
   margin: 0;
   padding: 0;
+  /*fix flickering when used background-image instead of <img> (on Chrome)*/
+  -webkit-perspective: 1000;
 }
 ul.bxslider {
   list-style: none;


### PR DESCRIPTION
Fixing flickering (on -webkit)  when used background-image to `<li>` tag instead of `<img>` tag.
See please my question that answered myself on [stackoverflow](http://stackoverflow.com/a/34363616/5674366)
