### PR TITLE
jQuery 3 compatibility

### DIFF
--- a/src/js/jquery.bxslider.js
+++ b/src/js/jquery.bxslider.js
@@ -282,7 +282,7 @@
         $(this).one('load error', function() {
           if (++count === total) { callback(); }
         }).each(function() {
-          if (this.complete) { $(this).load(); }
+          if (this.complete) { $(this).trigger('load'); }
         });
       });
     };


### PR DESCRIPTION
jQuery 3.0 removed the event `.load()` method. Replacing it with `.trigger('load')` allows the script to continue functioning.
