### PR TITLE
Bind click actions to the controls

### DIFF
--- a/src/js/jquery.bxslider.js
+++ b/src/js/jquery.bxslider.js
@@ -667,6 +667,8 @@
       // bind click actions to the controls
       slider.controls.next.bind('click touchend', clickNextBind);
       slider.controls.prev.bind('click touchend', clickPrevBind);
+      $(slider.settings.prevSelector).bind('click', clickPrevBind);
+      $(slider.settings.nextSelector).bind('click', clickNextBind);      
       // if nextSelector was supplied, populate it
       if (slider.settings.nextSelector) {
         $(slider.settings.nextSelector).append(slider.controls.next);


### PR DESCRIPTION
If **"prevSelector"** and **"nextSelector"** configuration options are set but **"prevText"** and **"nextText"** are empty, for example, `nextText:''`, the buttons don't work.
So, I bound the click event to these controls.