### PR TITLE
Add settings options for specifying control element type and class name(s)

### DIFF
--- a/src/js/jquery.bxslider.js
+++ b/src/js/jquery.bxslider.js
@@ -52,6 +52,8 @@
     prevText: 'Prev',
     nextSelector: null,
     prevSelector: null,
+    nextPrevEl: null,
+    nextPrevElClass: null,
     autoControls: false,
     startText: 'Start',
     stopText: 'Stop',
@@ -662,8 +664,19 @@
      * Appends prev / next controls to the controls element
      */
     var appendControls = function() {
-      slider.controls.next = $('<a class="bx-next" href="">' + slider.settings.nextText + '</a>');
-      slider.controls.prev = $('<a class="bx-prev" href="">' + slider.settings.prevText + '</a>');
+      // if nextPrevEl was supplied use it to construct control elements
+      if(slider.settings.nextPrevEl) {
+        slider.controls.next = $('<' + slider.settings.nextPrevEl + ' class="bx-next">' + slider.settings.nextText + '</' + slider.settings.nextPrevEl + '>');
+        slider.controls.prev = $('<' + slider.settings.nextPrevEl + ' class="bx-prev">' + slider.settings.prevText + '</' + slider.settings.nextPrevEl + '>');
+      } else {
+        slider.controls.next = $('<a class="bx-next" href="">' + slider.settings.nextText + '</a>');
+        slider.controls.prev = $('<a class="bx-prev" href="">' + slider.settings.prevText + '</a>');  
+      }
+      // if nextPrevElClass was supplied add to element
+      if(slider.settings.nextPrevElClass) {
+        slider.controls.next.addClass(slider.settings.nextPrevElClass);
+        slider.controls.prev.addClass(slider.settings.nextPrevElClass);
+      }
       // bind click actions to the controls
       slider.controls.next.bind('click touchend', clickNextBind);
       slider.controls.prev.bind('click touchend', clickPrevBind);


### PR DESCRIPTION
I ran into a use case where I wanted to use buttons instead of the <a> tags that the plugin generates for the next and prev controls. Additionally I needed to add some classes to those buttons. I thought this might be useful to other users as well, so I added them to the options object and modified the appendControls function.

nextPrevEl allows user to specify an html element for the next and prev controls (e.g. 'button')
nextPrevElClass allows user to add class(es) to the next and prev elements