### PR TITLE
Allow using newer node engines.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "handlebars-helpers": "~0.5.8"
   },
   "engines": {
-    "node": "~0.10.28"
+    "node": ">=0.10.28"
   },
   "keywords": [
     "responsive",


### PR DESCRIPTION
I am trying to install this package with `yarn` using node 4 LTS. `yarn` will not install this package before of this engine restriction. Is this restriction really necessary?
