### PR TITLE
Fix division by 0

### DIFF
--- a/src/js/jquery.bxslider.js
+++ b/src/js/jquery.bxslider.js
@@ -454,7 +454,7 @@
         } else {
           childWidth = slider.children.first().width() + slider.settings.slideMargin;
           slidesShowing = Math.floor((slider.viewport.width() +
-            slider.settings.slideMargin) / childWidth);
+            slider.settings.slideMargin) / childWidth) || 1;
         }
       // if "vertical" mode, slides showing will always be minSlides
       } else if (slider.settings.mode === 'vertical') {


### PR DESCRIPTION
When the slider viewport width + the slide's margin is just a few pixels smaller than the child width then getNumberSlidesShowing() returns 0.
That cause that within the function getPagerQty() is effected a division by 0 and this function returns Infinity wich throws Uncaught RangeError: Invalid string length within populatePager() due to an infinite "for" loop 
![bxslider console error](https://cloud.githubusercontent.com/assets/25935834/23182287/07c75eec-f846-11e6-9212-4a4816c7209a.png)


