### PR TITLE
Add main field

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "type": "git",
     "url": "https://github.com/stevenwanderski/bxslider-4/bxslider-4.git"
   },
+  "main": "dist/jquery.bxslider.js",
   "bugs": {
     "url": "https://github.com/stevenwanderski/bxslider-4/issues"
   },


### PR DESCRIPTION
Currently, when installing via NPM and requiring, the module will fail to resolve due to lack of "main" file.