### PR TITLE
Fix #1118

### DIFF
--- a/src/js/jquery.bxslider.js
+++ b/src/js/jquery.bxslider.js
@@ -1427,9 +1427,8 @@
           value = slider.settings.mode === 'horizontal' ? -(position.left - moveBy) : -position.top;
           // plugin values to be animated
           setPositionProperty(value, 'slide', slider.settings.speed);
-        } else {
-          slider.working = false;
         }
+          slider.working = false;
       }
       if (slider.settings.ariaHidden) { applyAriaHiddenAttributes(slider.active.index * getMoveBy()); }
     };


### PR DESCRIPTION
Ensure that `slider.working` is set to false at the end of `goToSlide()`, regardless of what happened with `position`.