### PR TITLE
remove unnecessary / duplicate boolean setting

### DIFF
--- a/src/js/jquery.bxslider.js
+++ b/src/js/jquery.bxslider.js
@@ -143,7 +143,7 @@
       // store active slide information
       slider.active = { index: slider.settings.startSlide };
       // store if the slider is in carousel mode (displaying / moving multiple slides)
-      slider.carousel = slider.settings.minSlides > 1 || slider.settings.maxSlides > 1 ? true : false;
+      slider.carousel = slider.settings.minSlides > 1 || slider.settings.maxSlides > 1;
       // if carousel, force preloadImages = 'all'
       if (slider.carousel) { slider.settings.preloadImages = 'all'; }
       // calculate the min / max width thresholds based on min / max number of slides


### PR DESCRIPTION
The explicit setting to `true` or `false` is unnecessary. If the purpose of having it there is to be easier for humans, then I'd suggest wrapping the `or` in parentheses.

(Note: thank PhpStorm for this suggestion, not me.)