### PR TITLE
InvalidPointerId on Android 6

### DIFF
--- a/src/js/jquery.bxslider.js
+++ b/src/js/jquery.bxslider.js
@@ -1102,6 +1102,7 @@
         slider.touch.originalPos = el.position();
         var orig = e.originalEvent,
         touchPoints = (typeof orig.changedTouches !== 'undefined') ? orig.changedTouches : [orig];
+	var chromePointerEvents = typeof PointerEvent === 'function'; if (chromePointerEvents) { if (orig.pointerId === undefined) { return; } }
         // record the starting touch x, y coordinates
         slider.touch.start.x = touchPoints[0].pageX;
         slider.touch.start.y = touchPoints[0].pageY;


### PR DESCRIPTION
I have been facing the same issue mentioned in below URL's 

It also contains the solution. Just sending PR to merge those changes.
https://github.com/stevenwanderski/bxslider-4/issues/1086#issuecomment-276687028
https://stackoverflow.com/questions/41541121/domexception-failed-to-execute-setpointercapture-on-element-and-releasepoin