### PR TITLE
Fix for Firefox59 issue #1188

### DIFF
--- a/src/js/jquery.bxslider.js
+++ b/src/js/jquery.bxslider.js
@@ -1106,7 +1106,7 @@
         slider.touch.start.x = touchPoints[0].pageX;
         slider.touch.start.y = touchPoints[0].pageY;
 
-        if (slider.viewport.get(0).setPointerCapture) {
+        if (slider.viewport.get(0).setPointerCapture && orig.pointerId > 0) {
           slider.pointerId = orig.pointerId;
           slider.viewport.get(0).setPointerCapture(slider.pointerId);
         }

--- a/src/js/jquery.bxslider.js
+++ b/src/js/jquery.bxslider.js
@@ -1159,7 +1159,6 @@
      *  - DOM event object
      */
     var onTouchMove = function(e) {
-      e.preventDefault();
       var orig = e.originalEvent,
       touchPoints = (typeof orig.changedTouches !== 'undefined') ? orig.changedTouches : [orig],
       // if scrolling on y axis, do not prevent default

--- a/src/js/jquery.bxslider.js
+++ b/src/js/jquery.bxslider.js
@@ -35,8 +35,6 @@
     touchEnabled: true,
     swipeThreshold: 50,
     oneToOneTouch: true,
-    preventDefaultSwipeX: true,
-    preventDefaultSwipeY: false,
 
     // ACCESSIBILITY
     ariaLive: true,
@@ -1091,7 +1089,11 @@
      *  - DOM event object
      */
     var onTouchStart = function(e) {
-      e.preventDefault();
+      // watch only for left mouse, touch contact and pen contact
+      // touchstart event object doesn`t have button property
+      if (e.type !== 'touchstart' && e.button !== 0) {
+        return;
+      }
       //disable slider controls while user is interacting with slides to avoid slider freeze that happens on touch devices when a slide swipe happens immediately after interacting with slider controls
       slider.controls.el.addClass('disabled');
 
@@ -1113,6 +1115,8 @@
         // store original event data for click fixation
         slider.originalClickTarget = orig.originalTarget;
         slider.originalClickButton = orig.button;
+        slider.originalClickButtons = orig.buttons;
+        slider.originalEventType = orig.type;
         // at this moment we don`t know what it is click or swipe
         slider.hasMove = false;
         // bind a "touchmove" event to the viewport
@@ -1240,10 +1244,14 @@
       if(slider.viewport.get(0).releasePointerCapture) {
         slider.viewport.get(0).releasePointerCapture(slider.pointerId);
       }
-      // if slider had swipe with left mouse button or touch
-      if (slider.hasMove === false && slider.originalClickButton === 0) {
+      // if slider had swipe with left mouse, touch contact and pen contact
+      if (slider.hasMove === false && (slider.originalClickButton === 0 || slider.originalEventType === 'touchstart')) {
         // trigger click event (fix for Firefox59 and PointerEvent standard compatibility)
-        $(slider.originalClickTarget).trigger('click');
+        $(slider.originalClickTarget).trigger({
+          type: 'click',
+          button: slider.originalClickButton,
+          buttons: slider.originalClickButtons
+        });
       }
     };
 

--- a/src/js/jquery.bxslider.js
+++ b/src/js/jquery.bxslider.js
@@ -1108,7 +1108,7 @@
         slider.touch.start.x = touchPoints[0].pageX;
         slider.touch.start.y = touchPoints[0].pageY;
 
-        if(slider.viewport.get(0).setPointerCapture) {
+        if (slider.viewport.get(0).setPointerCapture) {
           slider.pointerId = orig.pointerId;
           slider.viewport.get(0).setPointerCapture(slider.pointerId);
         }
@@ -1144,7 +1144,7 @@
       slider.viewport.unbind('MSPointerCancel pointercancel', onPointerCancel);
       slider.viewport.unbind('touchmove MSPointerMove pointermove', onTouchMove);
       slider.viewport.unbind('touchend MSPointerUp pointerup', onTouchEnd);
-      if(slider.viewport.get(0).releasePointerCapture) {
+      if (slider.viewport.get(0).releasePointerCapture) {
         slider.viewport.get(0).releasePointerCapture(slider.pointerId);
       }
     };
@@ -1223,7 +1223,6 @@
         // if not infinite loop and first / last slide, do not attempt a slide transition
         if (!slider.settings.infiniteLoop && ((slider.active.index === 0 && distance > 0) || (slider.active.last && distance < 0))) {
           setPositionProperty(value, 'reset', 200);
-
         } else {
           // check if distance clears threshold
           if (Math.abs(distance) >= slider.settings.swipeThreshold) {
@@ -1241,7 +1240,7 @@
       }
       slider.viewport.unbind('touchend MSPointerUp pointerup', onTouchEnd);
 
-      if(slider.viewport.get(0).releasePointerCapture) {
+      if (slider.viewport.get(0).releasePointerCapture) {
         slider.viewport.get(0).releasePointerCapture(slider.pointerId);
       }
       // if slider had swipe with left mouse, touch contact and pen contact

--- a/src/js/jquery.bxslider.js
+++ b/src/js/jquery.bxslider.js
@@ -35,6 +35,8 @@
     touchEnabled: true,
     swipeThreshold: 50,
     oneToOneTouch: true,
+    preventDefaultSwipeX: true,
+    preventDefaultSwipeY: false,
 
     // ACCESSIBILITY
     ariaLive: true,
@@ -1094,6 +1096,7 @@
       if (e.type !== 'touchstart' && e.button !== 0) {
         return;
       }
+      e.preventDefault();
       //disable slider controls while user is interacting with slides to avoid slider freeze that happens on touch devices when a slide swipe happens immediately after interacting with slider controls
       slider.controls.el.addClass('disabled');
 
@@ -1166,6 +1169,17 @@
       change = 0;
       // this is swipe
       slider.hasMove = true;
+
+      // x axis swipe
+      if ((xMovement * 3) > yMovement && slider.settings.preventDefaultSwipeX) {
+        e.preventDefault();
+      // y axis swipe
+      } else if ((yMovement * 3) > xMovement && slider.settings.preventDefaultSwipeY) {
+        e.preventDefault();
+      }
+      if (e.type !== 'touchmove') {
+        e.preventDefault();
+      }
 
       if (slider.settings.mode !== 'fade' && slider.settings.oneToOneTouch) {
         // if horizontal, drag along x axis


### PR DESCRIPTION
There are several changes in events handling.
Prevent default behaviour in Pointer events, this is specification recommendation. Also this makes behaviour of different browser engines similar and expectable.
Because Firefox59 doesn't fire click event after listening pointer events this patch determine and trigger it.
Details: [https://github.com/stevenwanderski/bxslider-4/issues/1188#issuecomment-376246974](url)
