### PR TITLE
Bug Fix moveSlides > 1 breaks getPagerQty()

### DIFF
--- a/src/js/jquery.bxslider.js
+++ b/src/js/jquery.bxslider.js
@@ -483,11 +483,11 @@
         } else {
           // when breakpoint goes above children length, counter is the number of pages
           while (breakPoint < slider.children.length) {
-            ++pagerQty;
-            breakPoint = counter + getNumberSlidesShowing();
-            counter += slider.settings.moveSlides <= getNumberSlidesShowing() ? slider.settings.moveSlides : getNumberSlidesShowing();
-          }
-		  return counter;
+              ++pagerQty;
+              breakPoint = counter + getNumberSlidesShowing();
+              counter += slider.settings.moveSlides < getNumberSlidesShowing() ? slider.settings.moveSlides : getNumberSlidesShowing();
+          } 
+		      return pagerQty;
         }
       // if moveSlides is 0 (auto) divide children length by sides showing, then round up
       } else {


### PR DESCRIPTION
Came across this issue where if you set moveSlides > 1 and inifinteLoop == false then the getPagerQty() function reports the wrong number of pages which causes the pager to multifunction there is also a knock-on effect with the next button if hideControlOnEnd == true ( this is how I bumped into this issue ) which then does the following: 
- Doesn't disable when the last item is reached.
- Allows you to go keep incrementing the pager even when there is no content to display.

I believe this issue was originally reported here: https://github.com/stevenwanderski/bxslider-4/issues/1224 you can also see the issue in the original post via JS fiddle.